### PR TITLE
fix URL path for build command, old URL down.

### DIFF
--- a/build_complete.sh
+++ b/build_complete.sh
@@ -91,7 +91,7 @@ sigint_handler() {
 }
 trap sigint_handler SIGINT
 
-shim_url="https://dl.darkn.bio/api/raw/?path=/SH1mmer/$board.zip"
+shim_url="https://ddl.kxtz.dev/api/v1/download?path=/ChromeOS/shims/Raw/$board.zip"
 boards_url="https://chromiumdash.appspot.com/cros/fetch_serving_builds?deviceCategory=ChromeOS"
 
 if [ -z "$data_dir" ]; then


### PR DESCRIPTION
This changes the domain used in the `build_complete.sh` script to use a working domain.