### PR TITLE
update bash shebangs for non-FHS compatibility

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #build the bootloader image
 

--- a/build_complete.sh
+++ b/build_complete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . ./common.sh
 . ./image_utils.sh

--- a/build_rootfs.sh
+++ b/build_rootfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #build the debian rootfs
 

--- a/build_squashfs.sh
+++ b/build_squashfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #build a rootfs that uses a squashfs + unionfs
 #consists of a minimal busybox system containing:

--- a/common.sh
+++ b/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 if [ "$DEBUG" ]; then

--- a/image_utils.sh
+++ b/image_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 create_loop() {
   local loop_device=$(losetup -f)
   if [ ! -b "$loop_device" ]; then

--- a/patch_rootfs.sh
+++ b/patch_rootfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #patch the target rootfs to add any needed drivers
 

--- a/shim_utils.sh
+++ b/shim_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #utilties for reading shim disk images
 


### PR DESCRIPTION
 `#!/bin/sh` fails on non-FHS systems like NixOS:
 ```bash
[nix-shell:~/shimboot]$ sudo ./build_complete.sh dedede release=bookworm
[sudo] password for popcat19: 
sudo: unable to execute ./build_complete.sh: No such file or directory
```

Having `#!/usr/bin/env bash` uses the system-wide bash in PATH, in NixOS case would usually be:
```bash
[nix-shell:~/shimboot]$ which bash
/nix/store/fdjz8wqw1yfh3pb58vrsswc30qwz42mx-bash-interactive-5.3p3/bin/bash
```
---
[build-log](https://pastebin.com/yyP4H8zU)