### PR TITLE
fix(kill_frecon): add delay to prevent black screen on AMD devices

### DIFF
--- a/rootfs/usr/local/bin/kill_frecon
+++ b/rootfs/usr/local/bin/kill_frecon
@@ -2,5 +2,10 @@
 
 #this script handles unmounting the console and killing frecon so that xorg can start
 
-umount -l /dev/console 
-pkill frecon-lite
+#wait for display manager to be ready before killing frecon
+#this helps prevent black screen issues on some devices (e.g., AMD Zork)
+sleep 2
+
+#unmount console and kill frecon
+umount -l /dev/console 2>/dev/null || true
+pkill frecon-lite 2>/dev/null || true


### PR DESCRIPTION
The kill_frecon script kills frecon-lite immediately when the graphical target is reached. On AMD Zork devices and some other hardware, this causes a black screen because the display manager isn't fully initialized when frecon is killed.

Added a 2-second delay to let the display manager claim the framebuffer before frecon exits. Also added error handling so the script won't fail if the console is already unmounted.

Fixes #500