### PR TITLE
Add script to handle changing time zones

### DIFF
--- a/rootfs/usr/local/bin/set_timezone
+++ b/rootfs/usr/local/bin/set_timezone
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+print_help() {
+  echo "Usage: sudo set_timezone timezone"
+  echo "    See https://nodatime.org/TimeZones for a list of valid time zones."
+  echo "    If you can't open the link by clicking it, try holding control and clicking."
+}
+
+#yoinked these two if statements from common.sh because i need them
+if [ "$EUID" -ne 0 ]; then
+  printf "\033[1;31mThis script needs to be run as root.\033[0m\n"
+  exit 1
+fi
+
+if [ -z "$1" ]; then
+  print_help
+  exit 1
+fi
+
+
+time_zone="$1"
+ln -sf "/usr/share/zoneinfo/${1}" "/etc/localtime"
+printf "Time zone changed to \033[1;32m${time_zone}\033[0m.\n"


### PR DESCRIPTION
Using timedatectl or Plasma System Settings to change the time zone did not work, but this script did. Implementation is a bit quirky, but in testing I was able to change my time zone to `America/New_York` with no problem. Doing it this way also allows it to persist between reboots.

Internally, the script just changes the symlink for `/etc/localtime` to whatever the user gives. Everything else isn't important.

Below is a screenshot of the script in use on a `dedede` motherboard (if that matters).
<img width="653" height="144" alt="Screenshot_20260330_124859" src="https://github.com/user-attachments/assets/2c559186-6672-47ea-b2d1-b834585a1e8e" />

Additional guidance is needed to tell the user to run this script, but I don't feel like writing that right now.