### PR TITLE
Set PATH to prevent setup_alpine_rootfs.sh to fail

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -13,6 +13,11 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: remove snap
+        uses: ading2210/gh-actions-remove-snap@v1
+        with:
+          disable_man_db: 'true'
+
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:

--- a/rootfs/opt/setup_rootfs_alpine.sh
+++ b/rootfs/opt/setup_rootfs_alpine.sh
@@ -19,6 +19,9 @@ enable_root="$8"
 disable_base_pkgs="$9"
 arch="${10}"
 
+#set PATH to execute binaries
+export PATH="/sbin:/bin:/usr/bin:/usr/local/bin:/usr/sbin"
+
 #set hostname and apk repos
 setup-hostname "$hostname"
 setup-apkrepos \


### PR DESCRIPTION
Set this PATH variable (`export PATH="/sbin:/bin:/usr/bin:/usr/local/bin:/usr/sbin"`) to the script `rootfs/opt/setup_alpine_rootfs.sh` which exports the location of all installed binaries in order for the chroot environment to not fail.

### Problem:

Executing:
```
sudo ./build_complete.sh <board_name> distro=alpine
```
will result in this error:
```
/opt/setup_rootfs_alpine.sh: line 23: setup-hostname: not found
```
instead of successfully continuing the script.

This is because the `setup-*` scripts Alpine included (and possibly all binaries) was nowhere to be found. The only way to fix this is by manually setting the PATH inside the script for the installed binaries to work.

### Issues reporting this:

https://github.com/ading2210/shimboot/issues/510
https://github.com/ading2210/shimboot/issues/212 < the person who made the issue already fixed it themselves, all you have to do is include the PATH inside the script